### PR TITLE
Add tape density translation for LTO-5 and LTO-6

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -231,6 +231,8 @@ static struct densities {
     {0x4b, "T10000B"},
     {0x51, "IBM 3592 J1A"},
     {0x52, "IBM 3592 E05"},
+    {0x58, "LTO-5"},
+    {0x5a, "LTO-6"},
     {0x80, "DLT 15GB uncomp. or Ecrix"},
     {0x81, "DLT 15GB compressed"},
     {0x82, "DLT 20GB uncompressed"},


### PR DESCRIPTION
The codes used have been extracted from the mhvtl project.
