### PR TITLE
Change default tape device to /dev/nst0

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -26,7 +26,7 @@
 #include "version.h"
 
 #ifndef DEFTAPE
-#define DEFTAPE "/dev/tape"     /* default tape device */
+#define DEFTAPE "/dev/nst0"     /* default tape device */
 #endif /* DEFTAPE */
 
 typedef int (* cmdfunc)(/* int, struct cmdef_tr *, int, char ** */);


### PR DESCRIPTION
Modern distributions doesn't have /dev/tape as link to /dev/nst0 any more. Instead it uses udev and creates different names in /dev/tape/by-id/ directory. So let's use /dev/nst0 for default tape device.
