### PR TITLE
Add IBM 3590 B/E format to tape densities table

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -176,6 +176,7 @@ static struct densities {
     { 0x27, "Exabyte Mammoth"                },
     { 0x28, "Exabyte Mammoth-2"              },
     { 0x29, "QIC-3080MC"                     },
+    { 0x2a, "IBM 3590 E"                     },
     { 0x30, "AIT-1 or MLR3"                  },
     { 0x31, "AIT-2"                          },
     { 0x32, "AIT-3 or SLR7"                  },

--- a/mt.c
+++ b/mt.c
@@ -175,7 +175,7 @@ static struct densities {
     { 0x26, "DDS-4 or QIC-4GB"               },
     { 0x27, "Exabyte Mammoth"                },
     { 0x28, "Exabyte Mammoth-2"              },
-    { 0x29, "QIC-3080MC"                     },
+    { 0x29, "QIC-3080MC, IBM 3590 B"         },
     { 0x2a, "IBM 3590 E"                     },
     { 0x30, "AIT-1 or MLR3"                  },
     { 0x31, "AIT-2"                          },


### PR DESCRIPTION
This PR Adds one line to include the format code for the IBM 3590 E format cartridge.

I would like to add the IBM 3590 B format cartridge as well (its hex code is 0x29) but this code is already in use by the QIC-3080.
I am not sure how to resolve this? 