### PR TITLE
add 3490E to tape type for code 0x09

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -144,7 +144,7 @@ static struct densities {
     { 0x06, "PE (3200 bpi)"                  },
     { 0x07, "IMFM (6400 bpi)"                },
     { 0x08, "GCR (8000 bpi)"                 },
-    { 0x09, "GCR (37871 bpi)"                },
+    { 0x09, "3490E, GCR (37871 bpi)"         },
     { 0x0a, "MFM (6667 bpi)"                 },
     { 0x0b, "PE (1600 bpi)"                  },
     { 0x0c, "GCR (12960 bpi)"                },

--- a/mt.c
+++ b/mt.c
@@ -144,7 +144,7 @@ static struct densities {
     { 0x06, "PE (3200 bpi)"                  },
     { 0x07, "IMFM (6400 bpi)"                },
     { 0x08, "GCR (8000 bpi)"                 },
-    { 0x09, "3490E, GCR (37871 bpi)"         },
+    { 0x09, "3480/3490E, GCR (37871 bpi)"    },
     { 0x0a, "MFM (6667 bpi)"                 },
     { 0x0b, "PE (1600 bpi)"                  },
     { 0x0c, "GCR (12960 bpi)"                },


### PR DESCRIPTION
This PR adds a single entry to the Tape Densities table for tapes with the hex code 0x09. The industry name for these tapes is 3490E. 

Edit: here is an image of the 3490E Tape I used. I have had to redact the label:
![3490E](https://github.com/user-attachments/assets/3cd3128c-b4bb-4cde-9348-4e6e6c617cfd)
