### PR TITLE
Add abbreviation explainer for tape types in code comment

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -135,7 +135,7 @@ static struct densities {
     char *name;
 } density_tbl[] = {
     /* clang-format off */
-    /* Note:
+    /* Information taken from https://www.t10.org/ftp/x3t9.2/document.93/93-013r0.pdf:
      * NZRI: Non-Return to Zero, change on ones
      * GCR: Group Code Recording
      * PE: Phase Encoding
@@ -697,7 +697,7 @@ static int do_status(int mtfd,
 #define TAPE_NR(minor)                              \
     ((((minor) & ~255) >> (ST_NBR_MODE_BITS + 1)) | \
      ((minor) & ((1 << ST_MODE_SHIFT) - 1)))
-#define TAPE_MODE(minor) (((minor)&ST_MODE_MASK) >> ST_MODE_SHIFT)
+#define TAPE_MODE(minor) (((minor) & ST_MODE_MASK) >> ST_MODE_SHIFT)
 static const char *st_formats[] = { "",  "r", "k", "s", "l", "t", "o", "u",
                                     "m", "v", "p", "x", "a", "y", "q", "z" };
 

--- a/mt.c
+++ b/mt.c
@@ -135,6 +135,15 @@ static struct densities {
     char *name;
 } density_tbl[] = {
     /* clang-format off */
+    /* Note:
+     * NZRI: Non-Return to Zero, change on ones
+     * GCR: Group Code Recording
+     * PE: Phase Encoding
+     * IMFM: Inverted Modified Frequency Modulation
+     * MFM: Modified Frequency Modulation
+     * DDS: DAT Data Storage
+     * RLL: Run Length Limited
+     */
     { 0x00, "default"                        },
     { 0x01, "NRZI (800 bpi)"                 },
     { 0x02, "PE (1600 bpi)"                  },


### PR DESCRIPTION
This is a non-functional change.

It adds a comment explaining the acronyms used in the tape densities table.

The source of this information was this document from 1993:

[Source: Warning PDF](https://www.t10.org/ftp/x3t9.2/document.93/93-013r0.pdf)