### PR TITLE
Add 9track Reels to tape struct densities table

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -136,12 +136,12 @@ static struct densities {
 } density_tbl[] = {
     /* clang-format off */
     { 0x00, "default"                        },
-    { 0x01, "NRZI (800 bpi)"                 },
-    { 0x02, "PE (1600 bpi)"                  },
-    { 0x03, "GCR (6250 bpi)"                 },
+    { 0x01, "NRZI (800 bpi) 9 Track Reel"    },
+    { 0x02, "PE (1600 bpi) 9 Track Reel"     },
+    { 0x03, "GCR (6250 bpi) 9 Track Reel"    },
     { 0x04, "QIC-11"                         },
     { 0x05, "QIC-45/60 (GCR, 8000 bpi)"      },
-    { 0x06, "PE (3200 bpi)"                  },
+    { 0x06, "PE (3200 bpi) 9 Track Reel"     },
     { 0x07, "IMFM (6400 bpi)"                },
     { 0x08, "GCR (8000 bpi)"                 },
     { 0x09, "GCR (37871 bpi)"                },


### PR DESCRIPTION
This PR Specifies which of the entries in the tape density table are 9 Track Reel style tapes like the ones found [here](https://en.wikipedia.org/wiki/9-track_tape).