### PR TITLE
Add stoptions to bash autocomplete

### DIFF
--- a/mt-st.bash_completion
+++ b/mt-st.bash_completion
@@ -6,7 +6,7 @@ _mt () {
     _init_completion || return
 
     #possible commands
-    commands="weof wset eof fsf fsfm bsf bsfm fsr bsr fss bss rewind offline rewoffl eject retension eod seod seek tell status erase setblk lock unlock load compression setdensity drvbuffer stwrthreshold stoptions stsetoptions stclearoptions defblksize defdensity defdrvbuffer defcompression stsetcln sttimeout stlongtimeout densities setpartition mkpartition partseek asf stshowopt"
+    commands="weof wset eof fsf fsfm bsf bsfm fsr bsr fss bss rewind offline rewoffl eject retension eod seod seek tell status erase setblk lock unlock load compression setdensity drvbuffer stwrthreshold stoptions stsetoptions stclearoptions defblksize defdensity defdrvbuffer defcompression stsetcln sttimeout stlongtimeout densities setpartition mkpartition partseek asf stshowoptions"
 
     COMPREPLY=()
 

--- a/mt-st.bash_completion
+++ b/mt-st.bash_completion
@@ -7,6 +7,7 @@ _mt () {
 
     #possible commands
     commands="weof wset eof fsf fsfm bsf bsfm fsr bsr fss bss rewind offline rewoffl eject retension eod seod seek tell status erase setblk lock unlock load compression setdensity drvbuffer stwrthreshold stoptions stsetoptions stclearoptions defblksize defdensity defdrvbuffer defcompression stsetcln sttimeout stlongtimeout densities setpartition mkpartition partseek asf stshowoptions"
+    stoptions="buffer-writes async-writes read-ahead debug two-fms fast-eod no-wait weof-no-wait auto-lock def-writes can-bsr no-blklimits can-partitions scsi2logical sili sysv"
 
     COMPREPLY=()
 
@@ -22,7 +23,18 @@ _mt () {
             COMPREPLY=($(compgen -W "$devs" -- "$cur"))
             return
             ;;
+	stsetoptions)
+	    # show list of stoptions
+	    COMPREPLY=($(compgen -W "$stoptions" -- "$cur"))
+            return
+            ;;
     esac
+
+    # if "$prev" is a substring of "$stoptions" show more "$stoptions"
+    if [[ "$stoptions" == *"$prev"* ]]; then
+	    COMPREPLY=($(compgen -W "$stoptions" -- "$cur"))
+            return
+    fi
 
     if [[ $cur == -* ]]; then
         COMPREPLY=($(compgen -W '-f -v' -- "$cur"))


### PR DESCRIPTION
Heya @iustin ,

I was fiddling with the bash autocompletion code this morning and something that has long annoyed me about mt is that when setting stoptions it doesn't suggest values to you. This PR changes this by showing valid options when running `stsetoptions` within `mt`.

It also patches an issue where previously autocomplete would suggest `stshowopt` instead of `stshowoptions`.

Sorry about the bash abomination on the new line 34. It was the shortest way I could think of doing a substring within a string match. I got the idea from [here](https://linuxize.com/post/how-to-check-if-string-contains-substring-in-bash/).