### PR TITLE
Update man page to show how to perform a quick tape erase

### DIFF
--- a/mt.1
+++ b/mt.1
@@ -94,7 +94,10 @@ setmarks at current position (only SCSI tape).
 .IP erase
 Erase the tape. Note that this is a long erase, which on modern
 (high-capacity) tapes can take many hours, and which usually can't be
-aborted.
+aborted. Setting 
+.I count
+to zero performs a non-secure quick erase of the tape. Quick erase
+support depends on drive type.
 .IP status
 Print status information about the tape unit. (If the density code is
 "no translation" in the status output, this does not affect working of the


### PR DESCRIPTION
Hi @iustin ,

I got stuck down a rabbit hole last week looking at #16 .

I tracked the code all the way back to the IOCTL call and can see that any parameter passed into `mt`, gets forward into the  IOCTL. I spent part of the weekend performing the following tests I have appended as a post script. As you can see parsing a parameter of `0` to the erase command, tells the drive to perform a non-secure quick erasure, likely an EOD at the start of the tape, but I assume this varies by tape drive. This functionality already exists in the code so I have updated the man page to explain this. **This Pull request is a non-functional change to the codebase**. Happy for you to modify the exact wording of the PR as you see fit.

### Test setup:

- Operating system: Ubuntu 22.04.5 LTS
- kernel: 5.15.0-177-generic
- mt-st version: 1.4-2 (it's old, sorry!)
- Drive: HPE Ultrium LTO8 with Firmware version N4Q1
- Cartridge : LTO-8
- Attachment method: SAS via LSI SAS2308

The test is: 

1.  write 100GB of data to the tape. 
2. Rewind. 
3. Erase the tape using various parameters. 
4. Time the erasure.

### **Test 1:** `mt erase`
```
$ dd if=/dev/urandom bs=512k count=200000 of=/dev/nst0; mt -f /dev/nst0 rewind;  time mt -f /dev/nst0 erase
200000+0 records in
200000+0 records out
104857600000 bytes (105 GB, 98 GiB) copied, 559.485 s, 185 MB/s

real	684m56.069s
user	0m0.001s
sys	    0m0.002s

```

### **Test 2:** `mt erase 1`
```
$ dd if=/dev/urandom bs=512k count=200000 of=/dev/nst0; mt -f /dev/nst0 rewind;  time mt -f /dev/nst0 erase 1
200000+0 records in
200000+0 records out
104857600000 bytes (105 GB, 98 GiB) copied,  565.317 s, 185 MB/s

real	680m7.214s
user	0m0.001s
sys	    0m0.003s

```

### **Test 3:** `mt erase 0`
```
$ dd if=/dev/urandom bs=512k count=200000 of=/dev/nst0; mt -f /dev/nst0 rewind;  time mt -f /dev/nst0 erase 0
200000+0 records in
200000+0 records out
104857600000 bytes (105 GB, 98 GiB) copied, 567.02 s, 185 MB/s

real	0m4.263s
user	0m0.000s
sys	    0m0.003s

```